### PR TITLE
Fix GPU device validation

### DIFF
--- a/chain_of_thought_gui.py
+++ b/chain_of_thought_gui.py
@@ -63,7 +63,7 @@ logger.setLevel(logging.INFO) # Set default level to INFO
 # The wrapper now needs to accept the processor (tokenizer + image processor).
 try:
     # Ensure the wrapper is imported correctly
-    from chain_of_thought_wrapper import ChainOfThoughtWrapper
+    from chain_of_thought_wrapper import ChainOfThoughtWrapper, validate_device_selection
     logger.info("Successfully imported ChainOfThoughtWrapper.")
 except ImportError:
     logger.error("🚨 Fatal Error: `chain_of_thought_wrapper.py` not found. Please ensure the enhanced wrapper script is in the same directory.")
@@ -1432,7 +1432,9 @@ try:
         logger.info("No NVML-compatible GPU devices found.")
     else:
          # Check if the selected device is a CUDA device and if telemetry works for it
-         selected_device = st.session_state.get("device_select", "cpu")
+         selected_device = validate_device_selection(
+             st.session_state.get("device_select", "cpu")
+         )
          if selected_device.startswith("cuda"):
               try:
                    # Attempt to get handle for the selected cuda device index
@@ -1464,7 +1466,9 @@ telemetry_placeholder = st.sidebar.empty() # Place in sidebar
 def update_telemetry():
     """Updates the telemetry display in the dedicated placeholder."""
     telemetry_text = "📊 System Status: [Initializing...]"
-    selected_device = st.session_state.get("device_select", "cpu")
+    selected_device = validate_device_selection(
+        st.session_state.get("device_select", "cpu")
+    )
 
     if not GPU_AVAILABLE or not selected_device.startswith("cuda"):
         telemetry_text = "📊 System Status: [No Compatible GPU Available or Selected for Telemetry]"
@@ -1952,6 +1956,11 @@ with st.sidebar:
         key="device_select", # Persistent key
         help="Select the device (CPU or GPU) to load the model onto. Larger or multimodal models often require GPU."
     )
+    # Validate device choice against current CUDA availability
+    validated_device = validate_device_selection(device_select)
+    if validated_device != device_select:
+        st.session_state.device_select = validated_device
+        device_select = validated_device
 
     # Load Model Button
     if st.button("Load Model"):

--- a/chain_of_thought_wrapper.py
+++ b/chain_of_thought_wrapper.py
@@ -163,6 +163,27 @@ def normalize_answer(answer: str) -> str:
 
     return normalized
 
+
+def validate_device_selection(selected_device: str) -> str:
+    """Validate CUDA device selection and fall back to CPU when invalid."""
+    if isinstance(selected_device, str) and selected_device.startswith("cuda"):
+        if not torch.cuda.is_available():
+            logger.warning("CUDA not available. Falling back to CPU.")
+            return "cpu"
+        try:
+            index = int(selected_device.split(":")[-1]) if ":" in selected_device else 0
+        except ValueError:
+            logger.warning(
+                f"Invalid CUDA device specification '{selected_device}'. Falling back to CPU."
+            )
+            return "cpu"
+        if index >= torch.cuda.device_count():
+            logger.warning(
+                f"Selected CUDA device index {index} is out of range (Max index: {torch.cuda.device_count() - 1}). Falling back to CPU."
+            )
+            return "cpu"
+    return selected_device
+
 # NOTE: This voting function is for the EXAMPLE USAGE BLOCK only and is NOT
 # directly used by the ChainOfThoughtWrapper.generate method.
 # It's included here for completeness if the user wanted to test the wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,10 @@ def dependency_stubs():
         def empty_cache() -> None:
             pass
 
+        @staticmethod
+        def device_count() -> int:
+            return 0
+
     torch_stub.cuda = DummyCuda()
     stubs["torch"] = torch_stub
 

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+import pytest
+
+# Make package importable when running tests from the repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+
+def test_fallback_when_cuda_unavailable(dependency_stubs, caplog):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: False
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import validate_device_selection
+    result = validate_device_selection("cuda:0")
+    assert result == "cpu"
+
+
+def test_fallback_on_invalid_index(dependency_stubs, caplog):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: True
+    torch.cuda.device_count = lambda: 1
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import validate_device_selection
+    result = validate_device_selection("cuda:5")
+    assert result == "cpu"
+
+
+def test_valid_device_kept(dependency_stubs):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: True
+    torch.cuda.device_count = lambda: 2
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import validate_device_selection
+    assert validate_device_selection("cuda:1") == "cuda:1"


### PR DESCRIPTION
## Summary
- add `validate_device_selection` helper in wrapper
- warn and fall back to CPU in GUI using new helper
- stub CUDA device count in tests
- test `validate_device_selection` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcab9bf4c833185e7c5cfdaac0d5a