### PR TITLE
Improve device validation

### DIFF
--- a/chain_of_thought_wrapper.py
+++ b/chain_of_thought_wrapper.py
@@ -170,18 +170,27 @@ def validate_device_selection(selected_device: str) -> str:
         if not torch.cuda.is_available():
             logger.warning("CUDA not available. Falling back to CPU.")
             return "cpu"
-        try:
-            index = int(selected_device.split(":")[-1]) if ":" in selected_device else 0
-        except ValueError:
-            logger.warning(
-                f"Invalid CUDA device specification '{selected_device}'. Falling back to CPU."
-            )
-            return "cpu"
-        if index >= torch.cuda.device_count():
+
+        # Default to device index 0 when none is specified
+        index = 0
+        if ":" in selected_device:
+            try:
+                index = int(selected_device.split(":")[-1])
+            except ValueError:
+                logger.warning(
+                    f"Invalid CUDA device specification '{selected_device}'. Falling back to CPU."
+                )
+                return "cpu"
+
+        if index < 0 or index >= torch.cuda.device_count():
             logger.warning(
                 f"Selected CUDA device index {index} is out of range (Max index: {torch.cuda.device_count() - 1}). Falling back to CPU."
             )
             return "cpu"
+
+        # Return the canonical device string
+        return f"cuda:{index}"
+
     return selected_device
 
 # NOTE: This voting function is for the EXAMPLE USAGE BLOCK only and is NOT

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -37,3 +37,23 @@ def test_valid_device_kept(dependency_stubs):
     sys.modules.pop("chain_of_thought_wrapper", None)
     from chain_of_thought_wrapper import validate_device_selection
     assert validate_device_selection("cuda:1") == "cuda:1"
+
+
+def test_canonical_index_returned(dependency_stubs):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: True
+    torch.cuda.device_count = lambda: 1
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import validate_device_selection
+    assert validate_device_selection("cuda") == "cuda:0"
+
+
+def test_negative_index_falls_back(dependency_stubs):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: True
+    torch.cuda.device_count = lambda: 1
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import validate_device_selection
+    assert validate_device_selection("cuda:-1") == "cpu"


### PR DESCRIPTION
## Summary
- improve `validate_device_selection` to normalize indexes
- add new unit tests for canonical CUDA strings and negative indexes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687be87eb99c833182f305c228ea728a