### PR TITLE
Ensure device validation in wrapper

### DIFF
--- a/chain_of_thought_wrapper.py
+++ b/chain_of_thought_wrapper.py
@@ -239,8 +239,13 @@ class ChainOfThoughtWrapper:
         """
         logger.debug("ChainOfThoughtWrapper __init__ started.")
         self.model = model
-        self.processor = processor # Store the processor (can be AutoProcessor or AutoTokenizer)
-        self.device = device
+        self.processor = processor  # Store the processor (can be AutoProcessor or AutoTokenizer)
+
+        # Validate the requested device string when provided
+        if isinstance(device, str):
+            self.device = validate_device_selection(device)
+        else:
+            self.device = device
         self.cot_instruction = cot_instruction
         self.reasoning_header = reasoning_header
         self.step_prefix = step_prefix

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -57,3 +57,12 @@ def test_negative_index_falls_back(dependency_stubs):
     sys.modules.pop("chain_of_thought_wrapper", None)
     from chain_of_thought_wrapper import validate_device_selection
     assert validate_device_selection("cuda:-1") == "cpu"
+
+def test_wrapper_validates_device(dependency_stubs):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: False
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import ChainOfThoughtWrapper
+    wrapper = ChainOfThoughtWrapper(model=None, processor=None, device="cuda:2")
+    assert wrapper.device == "cpu"


### PR DESCRIPTION
## Summary
- validate device strings inside `ChainOfThoughtWrapper.__init__`
- add a regression test for wrapper device validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bebe97fa08331baa93355f4a05369