### PR TITLE
Enhance GUI session tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Then open the local URL in your browser. Adjust model name, device, number of ch
 - **Copy button** on each code block for instant script copying.
 - **Responsive layout** that adapts to desktop and mobile screens.
 - **Telemetry panel** displaying GPU stats in real time.
+- **Download Chat History** option for saving transcripts.
+- **Reset Session** button to quickly clear the interface.
 
 ## ⏳ Example GUI Session
 

--- a/chain_of_thought_gui.py
+++ b/chain_of_thought_gui.py
@@ -2149,6 +2149,41 @@ with st.sidebar:
         logger.info("Chat history cleared and welcome message added.")
         st.rerun() # Rerun to clear the display
 
+    def _chat_history_to_text(history):
+        """Convert chat history to a plain text transcript."""
+        lines = []
+        for msg in history:
+            role = msg.get("role", "assistant")
+            content = msg.get("content", "")
+            msg_type = msg.get("type", "text")
+            if isinstance(content, dict):
+                if role == "user":
+                    user_text = content.get("text", "")
+                    lines.append(f"User: {user_text}")
+                    if content.get("image_data"):
+                        lines.append(f"[Attached {len(content.get('image_data'))} image(s)]")
+                elif msg_type == "cot_response":
+                    lines.append(f"Assistant: {content.get('main_output_display', '')}")
+                else:
+                    lines.append(f"{role}: {str(content)}")
+            else:
+                lines.append(f"{role}: {str(content)}")
+        return "\n".join(lines)
+
+    if st.session_state.chat_history:
+        history_text = _chat_history_to_text(st.session_state.chat_history)
+        st.download_button(
+            label="📥 Download Chat History",
+            data=history_text,
+            file_name="chat_history.txt",
+            mime="text/plain",
+        )
+
+    if st.button("Reset Session"):
+        logger.info("Reset Session button clicked.")
+        st.session_state.clear()
+        st.rerun()
+
 
     # Telemetry Footer (Automatically updated)
     # The telemetry_placeholder was defined before the sidebar


### PR DESCRIPTION
## Summary
- add utilities to download chat history or reset the session
- document the new GUI options in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687becf8607883318da6ea05d83dafaa