### PR TITLE
Handle GPU cache errors gracefully

### DIFF
--- a/chain_of_thought_gui.py
+++ b/chain_of_thought_gui.py
@@ -1548,10 +1548,14 @@ def _load_model_and_processor_cached(model_name: str, device: str):
              logger.error(f"Failed to load processor: {proc_e}")
              status_box.error(f"Failed to load processor for '{model_name}'. Details: {proc_e}")
              # Clean up resources
-             if model_config is not None: del model_config
-             if torch.cuda.is_available(): torch.cuda.empty_cache()
-             gc.collect()
-             return None, None, False # Return failure
+            if model_config is not None: del model_config
+            if torch.cuda.is_available():
+                try:
+                    torch.cuda.empty_cache()
+                except Exception as cleanup_e:
+                    logger.warning(f"Error during cuda empty_cache: {cleanup_e}")
+            gc.collect()
+            return None, None, False # Return failure
 
 
         # Determine appropriate dtype based on device and model config
@@ -1633,7 +1637,11 @@ def _load_model_and_processor_cached(model_name: str, device: str):
             if model is not None: del model
             if processor is not None: del processor
             if model_config is not None: del model_config
-            if torch.cuda.is_available(): torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                try:
+                    torch.cuda.empty_cache()
+                except Exception as cleanup_e:
+                    logger.warning(f"Error during cuda empty_cache: {cleanup_e}")
             gc.collect()
             return None, processor, False # Return None for model and False for multimodal on failure
 
@@ -1700,7 +1708,11 @@ def _load_model_and_processor_cached(model_name: str, device: str):
         if model is not None: del model
         if processor is not None: del processor
         if model_config is not None: del model_config
-        if torch.cuda.is_available(): torch.cuda.empty_cache()
+        if torch.cuda.is_available():
+            try:
+                torch.cuda.empty_cache()
+            except Exception as cleanup_e:
+                logger.warning(f"Error during cuda empty_cache: {cleanup_e}")
         gc.collect()
         # No re-raise here, return None and the calling function handles the error state
 

--- a/chain_of_thought_wrapper.py
+++ b/chain_of_thought_wrapper.py
@@ -772,7 +772,11 @@ class ChainOfThoughtWrapper:
         except Exception as e:
             logger.error("Failed to prepare input tensors (tokenization/image processing): %s", e)
             # Attempt cleanup before raising
-            if torch.cuda.is_available(): torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                try:
+                    torch.cuda.empty_cache()
+                except Exception as cleanup_e:
+                    logger.warning(f"Error during cuda empty_cache: {cleanup_e}")
             gc.collect()
             # Do not re-raise here, return empty lists and let the GUI handle the error
             return {"full_texts": [], "reasoning_steps": [], "final_answers": [], "generated_images": [], "generation_scores": None}
@@ -892,7 +896,11 @@ class ChainOfThoughtWrapper:
         except Exception as e:
             logger.error("Failed during model generation: %s", e)
             # Attempt cleanup before raising
-            if torch.cuda.is_available(): torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                try:
+                    torch.cuda.empty_cache()
+                except Exception as cleanup_e:
+                    logger.warning(f"Error during cuda empty_cache: {cleanup_e}")
             gc.collect()
             # Do not re-raise here, return empty lists and let the GUI handle the error
             return {"full_texts": [], "reasoning_steps": [], "final_answers": [], "generated_images": [], "generation_scores": None}


### PR DESCRIPTION
## Summary
- wrap `torch.cuda.empty_cache()` calls with try/except in wrapper and GUI
- prevent crashes when CUDA device-side asserts occur during cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf331bcc48331bab2696e95a20583