### PR TITLE
Fix indentation error in GUI

### DIFF
--- a/chain_of_thought_gui.py
+++ b/chain_of_thought_gui.py
@@ -1545,9 +1545,9 @@ def _load_model_and_processor_cached(model_name: str, device: str):
             logger.info(f"Processor loaded successfully. Processor type: {type(processor)}")
             status_box.write("Processor loaded. Loading model weights...")
         except Exception as proc_e:
-             logger.error(f"Failed to load processor: {proc_e}")
-             status_box.error(f"Failed to load processor for '{model_name}'. Details: {proc_e}")
-             # Clean up resources
+            logger.error(f"Failed to load processor: {proc_e}")
+            status_box.error(f"Failed to load processor for '{model_name}'. Details: {proc_e}")
+            # Clean up resources
             if model_config is not None: del model_config
             if torch.cuda.is_available():
                 try:

--- a/tests/test_device_selection.py
+++ b/tests/test_device_selection.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-import pytest
 
 # Make package importable when running tests from the repository root
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))


### PR DESCRIPTION
## Summary
- fix indentation of `del model_config` block
- remove unused `pytest` import in tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf5fd90e08331b63fe39ffaf5268d