### PR TITLE
Add roman numeral normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Then open the local URL in your browser. Adjust model name, device, number of ch
 - **Premium theme** option for a high-contrast look.
 - **Auto-scroll** feature to always show the latest message.
 - **Download Last Reasoning** button for saving the most recent answer.
+- **Roman numeral normalization** ensures outputs like "IV" convert to "4".
 
 ## ⏳ Example GUI Session
 

--- a/chain_of_thought_wrapper.py
+++ b/chain_of_thought_wrapper.py
@@ -163,6 +163,24 @@ def normalize_answer(answer: str) -> str:
     normalized_words = [num_word_map.get(word, word) for word in words]
     normalized = " ".join(normalized_words)
 
+    # Convert simple Roman numerals (length >= 2 to avoid the pronoun "I")
+    roman_pattern = re.compile(r"\b[ivxlcdm]{2,}\b", re.IGNORECASE)
+
+    def roman_to_int(roman: str) -> int:
+        values = {"I": 1, "V": 5, "X": 10, "L": 50, "C": 100, "D": 500, "M": 1000}
+        total = 0
+        prev = 0
+        for ch in roman.upper()[::-1]:
+            val = values.get(ch, 0)
+            if val < prev:
+                total -= val
+            else:
+                total += val
+                prev = val
+        return total
+
+    normalized = roman_pattern.sub(lambda m: str(roman_to_int(m.group(0))), normalized)
+
 
     # Remove extra whitespace within the string (replace multiple spaces with single)
     normalized = re.sub(r'\s+', ' ', normalized).strip()

--- a/tests/test_normalize_answer.py
+++ b/tests/test_normalize_answer.py
@@ -21,6 +21,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
         ("A quick BROWN Fox.", "quick brown fox"),
         ("Output -   ten.", "10"),
         ("Ninety-nine bottles!", "ninety-nine bottles"),
+        ("I have IV apples.", "i have 4 apples"),
+        ("Chapter XI", "chapter 11"),
         (123, ""),
         (["not", "a", "string"], ""),
     ],


### PR DESCRIPTION
## Summary
- normalize roman numerals in answers
- document normalization improvement
- test roman numeral handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f4bd1da148331a1566c6186f811d5