### PR TITLE
Add CLI entry point

### DIFF
--- a/cot_toolkit/cli.py
+++ b/cot_toolkit/cli.py
@@ -1,0 +1,37 @@
+import argparse
+import logging
+from . import ChainOfThoughtWrapper, validate_device_selection
+from transformers import AutoModel, AutoTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run the Chain-of-Thought wrapper from the command line")
+    parser.add_argument("model", help="Model name or path")
+    parser.add_argument("prompt", help="Prompt text to generate from")
+    parser.add_argument("--device", default="cpu", help="Device to load the model on")
+    parser.add_argument("--max-new-tokens", type=int, default=64, dest="max_new_tokens",
+                        help="Maximum new tokens to generate")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    device = validate_device_selection(args.device)
+    logger.info("Loading model %s", args.model)
+    model = AutoModel.from_pretrained(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    wrapper = ChainOfThoughtWrapper(model=model, processor=tokenizer, device=device)
+    result = wrapper.generate(args.prompt, generation_params={"max_new_tokens": args.max_new_tokens})
+    if result.get("final_answers"):
+        print(result["final_answers"][0])
+    elif result.get("full_texts"):
+        print(result["full_texts"][0])
+    else:
+        print("No output generated")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ py-modules = [
 
 [tool.setuptools.package-data]
 "" = ["*.py"]
+
+[project.scripts]
+cot-cli = "cot_toolkit.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from importlib import import_module
+
+
+def get_cli_module():
+    return import_module("cot_toolkit.cli")
+
+
+class DummyTensor:
+    def __init__(self, length):
+        self.shape = (1, length)
+        self.dtype = 'int64'
+        self.device = 'cpu'
+
+    def numel(self):
+        return self.shape[0] * self.shape[1]
+
+
+class DummyBatch(dict):
+    def to(self, device):
+        return self
+
+class DummyModel:
+    def generate(self, *args, **kwargs):
+        return types.SimpleNamespace(sequences=["dummy"])
+
+class DummyTokenizer:
+    pad_token_id = 0
+    eos_token_id = 1
+    def __call__(self, text, return_tensors=None, padding=None, truncation=True, max_length=None):
+        return DummyBatch({"input_ids": DummyTensor(1), "attention_mask": DummyTensor(1)})
+    def decode(self, ids, skip_special_tokens=True):
+        return "Step 1: foo\nFinal Answer: bar"
+
+
+def test_parse_args(dependency_stubs):
+    sys.modules.pop("cot_toolkit.cli", None)
+    cli = get_cli_module()
+    args = cli.parse_args(["model", "prompt", "--device", "cpu", "--max-new-tokens", "5"])
+    assert args.model == "model"
+    assert args.prompt == "prompt"
+    assert args.device == "cpu"
+    assert args.max_new_tokens == 5
+
+
+def test_main_runs(monkeypatch, dependency_stubs, capsys):
+    stubs = dependency_stubs
+    sys.modules.pop("cot_toolkit.cli", None)
+    monkeypatch.setattr(stubs["transformers"], "AutoModel", types.SimpleNamespace(from_pretrained=lambda m: DummyModel()))
+    monkeypatch.setattr(stubs["transformers"], "AutoTokenizer", types.SimpleNamespace(from_pretrained=lambda m: DummyTokenizer()))
+    cli = get_cli_module()
+
+    class DummyWrapper:
+        def __init__(self, *a, **k):
+            pass
+
+        def generate(self, *a, **k):
+            return {"final_answers": ["bar"], "full_texts": ["Step 1: foo\nFinal Answer: bar"]}
+
+    monkeypatch.setattr(cli, "ChainOfThoughtWrapper", DummyWrapper)
+
+    cli.main(["model", "prompt"])
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "bar"


### PR DESCRIPTION
## Summary
- provide a simple CLI utility to run the ChainOfThoughtWrapper from the terminal
- add entry point to `pyproject.toml`
- test command line argument parsing and basic execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fed57a3fc833189c0f6ed1d339d83