### PR TITLE
Enhance toolkit metrics and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Then open the local URL in your browser. Adjust model name, device, number of ch
 - **Download Chat History** option for saving transcripts.
 - **Reset Session** button to quickly clear the interface.
 - **Premium theme** option for a high-contrast look.
+- **Alien theme** for a vibrant sci‑fi aesthetic.
 - **Auto-scroll** feature to always show the latest message.
 - **Download Last Reasoning** button for saving the most recent answer.
 - **Generation duration** displayed for each response.
+- **GPU/CPU memory metrics** returned with each generation call.
 - **Roman numeral normalization** ensures outputs like "IV" convert to "4".
 - **Hyphenated number words** like "twenty-one" convert to digits for cleaner voting.
 

--- a/chain_of_thought_gui.py
+++ b/chain_of_thought_gui.py
@@ -120,7 +120,7 @@ st.set_page_config(
 with st.sidebar:
     theme_choice = st.selectbox(
         "🎨 Theme",
-        ["Dark", "Light", "Premium"],
+        ["Dark", "Light", "Premium", "Alien"],
         index=0,
         key="theme_select",
     )
@@ -177,6 +177,33 @@ h1, h2, h3, h4, h5, h6 {
 }
 .stButton>button:hover {
     background: linear-gradient(180deg, #B39BFF 0%, #9E84FF 100%) !important;
+}
+</style>
+"""
+
+ALIEN_THEME_CSS = """
+<style>
+html, body, [data-testid="stAppViewContainer"] {
+    color: #d0fffc !important;
+}
+.stApp {
+    background: radial-gradient(circle at 30% 30%, #002b36 0%, #001014 100%) !important;
+    color: #d0fffc !important;
+}
+.stSidebar {
+    background: linear-gradient(180deg, #00181e 0%, #002b36 100%) !important;
+    border-right: 1px solid #005f6b !important;
+}
+h1, h2, h3, h4, h5, h6 {
+    color: #2be4d4 !important;
+}
+.stButton>button {
+    background: linear-gradient(180deg, #2be4d4 0%, #008b94 100%) !important;
+    color: #001014 !important;
+    border: 1px solid #008b94 !important;
+}
+.stButton>button:hover {
+    background: linear-gradient(180deg, #5ffbf1 0%, #2be4d4 100%) !important;
 }
 </style>
 """
@@ -1460,6 +1487,8 @@ if theme_choice == "Light":
     st.markdown(LIGHT_THEME_CSS, unsafe_allow_html=True)
 elif theme_choice == "Premium":
     st.markdown(PREMIUM_THEME_CSS, unsafe_allow_html=True)
+elif theme_choice == "Alien":
+    st.markdown(ALIEN_THEME_CSS, unsafe_allow_html=True)
 
 # --- Code Copy Script ---
 st.markdown(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pynvml>=11.5.0",
     "numpy>=1.21.0",
     "pillow>=9.3.0",
+    "psutil>=5.9.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ streamlit>=1.24.0
 pynvml>=11.5.0
 numpy>=1.21.0
 pillow>=9.3.0
+psutil>=5.9.0

--- a/tests/test_device_metrics.py
+++ b/tests/test_device_metrics.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+def test_device_metrics_fallback_to_cpu(dependency_stubs):
+    torch = dependency_stubs["torch"]
+    torch.cuda.is_available = lambda: False
+    import sys
+    sys.modules.pop("chain_of_thought_wrapper", None)
+    from chain_of_thought_wrapper import get_device_metrics
+    metrics = get_device_metrics("cuda:0")
+    assert "cpu_memory_used_mb" in metrics
+    assert "cpu_memory_total_mb" in metrics


### PR DESCRIPTION
## Summary
- track GPU/CPU memory metrics with new `get_device_metrics`
- report memory stats before and after generation
- add optional Alien UI theme
- list Alien theme and device metrics in docs
- depend on `psutil` for metrics
- test device metrics fallback when CUDA is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fed57a3fc833189c0f6ed1d339d83