### PR TITLE
Add benchmarking helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ Then open the local URL in your browser. Adjust model name, device, number of ch
 - **Roman numeral normalization** ensures outputs like "IV" convert to "4".
 - **Hyphenated number words** like "twenty-one" convert to digits for cleaner voting.
 
+## 📊 Benchmarking
+
+Evaluate a wrapper's impact using the lightweight `benchmark_prompt` helper:
+
+```python
+from cot_toolkit import ChainOfThoughtWrapper, benchmark_prompt
+
+wrapper = ChainOfThoughtWrapper(model, tokenizer, device="cpu")
+metrics = benchmark_prompt(wrapper, "My prompt")
+print(metrics)
+```
+
+This runs generation with and without the CoT instruction and reports
+duration, final answers and step count.
+
 ## ⏳ Example GUI Session
 
 ```text

--- a/cot_toolkit/__init__.py
+++ b/cot_toolkit/__init__.py
@@ -5,11 +5,13 @@ from chain_of_thought_wrapper import (
     validate_device_selection,
     normalize_answer,
 )
+from .benchmark import benchmark_prompt
 
 __all__ = [
     "ChainOfThoughtWrapper",
     "validate_device_selection",
     "normalize_answer",
+    "benchmark_prompt",
 ]
 
 try:

--- a/cot_toolkit/benchmark.py
+++ b/cot_toolkit/benchmark.py
@@ -1,0 +1,45 @@
+"""Utility for benchmarking ChainOfThoughtWrapper output."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def benchmark_prompt(wrapper: Any, prompt: str, generation_params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Generate with and without chain-of-thought instructions and return metrics.
+
+    Parameters
+    ----------
+    wrapper : Any
+        Instance with ``generate`` method and ``cot_instruction`` attribute.
+    prompt : str
+        Prompt text to generate from.
+    generation_params : dict | None
+        Parameters forwarded to ``wrapper.generate``.
+
+    Returns
+    -------
+    dict
+        Dictionary containing generation durations and answers for both modes
+        as well as the number of reasoning steps when CoT is enabled.
+    """
+    generation_params = generation_params or {}
+
+    # Run generation with CoT enabled
+    result_cot = wrapper.generate(prompt, generation_params=generation_params)
+
+    # Temporarily disable CoT and run again
+    original_instruction = getattr(wrapper, "cot_instruction", "")
+    wrapper.cot_instruction = ""
+    try:
+        result_plain = wrapper.generate(prompt, generation_params=generation_params)
+    finally:
+        wrapper.cot_instruction = original_instruction
+
+    metrics = {
+        "cot_duration": result_cot.get("generation_duration"),
+        "plain_duration": result_plain.get("generation_duration"),
+        "cot_answer": (result_cot.get("final_answers") or [""])[0],
+        "plain_answer": (result_plain.get("final_answers") or [""])[0],
+        "cot_steps": len((result_cot.get("reasoning_steps") or [[]])[0]),
+    }
+    return metrics

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def import_benchmark():
+    return __import__("cot_toolkit.benchmark", fromlist=["benchmark_prompt"])
+
+
+class DummyWrapper:
+    def __init__(self):
+        self.cot_instruction = "Explain step"
+
+    def generate(self, prompt, generation_params=None, **kwargs):
+        if self.cot_instruction:
+            return {
+                "final_answers": ["cot"],
+                "reasoning_steps": [["a", "b"]],
+                "generation_duration": 0.2,
+            }
+        return {
+            "final_answers": ["plain"],
+            "reasoning_steps": [],
+            "generation_duration": 0.1,
+        }
+
+
+def test_benchmark_prompt(dependency_stubs):
+    wrapper = DummyWrapper()
+    sys.modules.pop("cot_toolkit.benchmark", None)
+    benchmark_prompt = import_benchmark().benchmark_prompt
+    metrics = benchmark_prompt(wrapper, "hi")
+    assert metrics["cot_steps"] == 2
+    assert metrics["cot_answer"] == "cot"
+    assert metrics["plain_answer"] == "plain"
+    assert wrapper.cot_instruction == "Explain step"


### PR DESCRIPTION
## Summary
- add `benchmark_prompt` utility for quick comparisons
- expose `benchmark_prompt` from the package
- document benchmarking usage in README
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ff0a8d3988331a7c42003aeee457f