### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -37,3 +39,28 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
+
+  publish:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        project-name: "cot-toolkit"


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to publish releases to PyPI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688043b505848331b27ac176c2cc4df7