### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+environment: pypi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -96,5 +96,11 @@ This prints a dictionary with durations and answers for each mode.
 - `wrapper.rag_helper.retrieve(query)` returns matching docs to insert into prompts.
 - The wrapper automatically references previous chat history when answering.
 
+## 🚀 Releasing to PyPI
+This project uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via GitHub Actions.
+Create a GitHub release and the `release.yml` workflow will build and upload a new version.
+Ensure the `pypi` environment is configured with PyPI as a trusted publisher.
+
+
 ## 📜 License
 MIT


### PR DESCRIPTION
## Summary
- add `release.yml` GitHub Actions workflow to publish packages using Trusted Publishing
- document release process in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688043b505848331b27ac176c2cc4df7