### PR TITLE
Configure PyPI release workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,20 +11,24 @@ permissions:
 
 jobs:
   build:
-    environment: pypi         # ← Move it here, under the job
     runs-on: ubuntu-latest
+    environment: pypi
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
-      - name: Install build dependencies
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build psutil pytest
+          pip install -e . --no-deps
+
+      - name: Run tests
+        run: pytest -q
 
       - name: Build package
         run: python -m build

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ This prints a dictionary with durations and answers for each mode.
 
 ## 🚀 Releasing to PyPI
 This project uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via GitHub Actions.
-Create a GitHub release and the `release.yml` workflow will build and upload a new version.
-Ensure the `pypi` environment is configured with PyPI as a trusted publisher.
+Creating a GitHub release triggers the `python-app.yml` workflow which runs the tests,
+builds the package and uploads it to PyPI.
+Make sure the repository has a `pypi` environment configured as a Trusted Publisher.
 
 
 ## 📜 License


### PR DESCRIPTION
## Summary
- update README with release instructions
- run tests before publishing
- publish to PyPI using trusted publishing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68804d4d3884833188e2ad604f131ca6