### PR TITLE
Fix packaging metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "cot-toolkit"
 version = "1.0.0"
 description = "Chain-of-thought reasoning toolkit with GUI"
 authors = [ {name="OpenAI", email="opensource@example.com"} ]
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [


### PR DESCRIPTION
## Summary
- fix license field in `pyproject.toml` and include license file

## Testing
- `pytest -q`
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_688084fc01748331bd061cc0126cd19b